### PR TITLE
partial fix: two images for custom and default emojis

### DIFF
--- a/bottom_meme.py
+++ b/bottom_meme.py
@@ -34,7 +34,7 @@ async def on_message(message):
         print(f'Parsing message {replied} of content {replied.content}')
         custom_emojis = re.findall(r'<\w*:\w*:\d*>', replied.content)
         print(f'Found emojis {custom_emojis}')
-        for e in custom_emojis[:1]:
+        for e in custom_emojis:
             print(f'Checking emoji {e}')
             emoji = discord.PartialEmoji.from_str(e)
             url = emoji.url
@@ -74,6 +74,7 @@ async def on_message(message):
                 os.remove('out.png')
             foreground.close()
             os.remove(ftype)
+            return
 
         default_emojis = await split_count(replied.content)
         print("found default emojies: " + str(default_emojis))

--- a/bottom_meme.py
+++ b/bottom_meme.py
@@ -67,7 +67,7 @@ async def on_message(message):
             else:
                 print(f'Static emoji found')
                 background.paste(foreground, (350, 80), mask=foreground)
-                foreground.thumbnail((50, 50), Image.ANTIALIAS)
+                foreground.thumbnail((50, 50), Resampling.LANCZOS)
                 background.paste(foreground, (160, 550), mask=foreground)
                 background.save('out.png')
                 await replied.reply(file=discord.File('out.png'))


### PR DESCRIPTION
Fixed issue where the bot would send 2 images if there was both a custom and a default emoji in a message. Now it only sends one but prefers custom emotes (fix maybe?)

also replaced ANTIALIAS with LANCZOS because deprecated.